### PR TITLE
Added functionality of going to deep sleep when battery is 0%

### DIFF
--- a/Software/Firmware/src/main.cpp
+++ b/Software/Firmware/src/main.cpp
@@ -38,6 +38,8 @@ void loop()
   if ((millis() - gui_timer_handler) > 5)
   {
     lv_timer_handler();
+    if (!get_bat_charge_lvl())
+      enter_deep_sleep();
     gui_timer_handler = millis();
   }
 }


### PR DESCRIPTION
Hi Omar,

I managed to assemble and run OpenRAD. I created my own 3d printed case and USED a single 18650 type battery to power the Liligo T-Display board. The board manages charging of the battery properly and provides overvoltage protection. But it doesn't provide discharging protection. Most of the lithium batteries die (or degrade badly) when below 2.7V. 

I checked your code and found that you monitor the battery voltage using the analog input from the charger IC. I added a simple check to the main loop. If the battery percentage is 0 then ESP32 goes into deep sleep. This prevents battery from discharging to unsafe level. The 0% is at 3.2V threshold which is a safe choice (way above 2.7v). 

I did my testing and when reaching 0% battery the device goes blank and required to be woken up using long press of the ok button. It never powers down on usb power because the get_bat_charge_lvl() function always returns 100% when on external power.

Please review my change and merge it to the main branch. It helps a lot when operating on battery.